### PR TITLE
[wip] Feat/go metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/prometheus/client_golang v1.5.1
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	go.uber.org/zap v1.14.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
+github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/runtime/logger.go
+++ b/runtime/logger.go
@@ -78,3 +78,8 @@ func (l *logger) SLogger() *zap.SugaredLogger {
 func (l *logger) Loggers() (*zap.Logger, *zap.SugaredLogger) {
 	return l.logger, l.slogger
 }
+
+// Implement go-metrics.Logger interface
+func (l *logger) Printf(format string, v ...interface{}) {
+	l.slogger.Infof(format, v...)
+}

--- a/runtime/logger.go
+++ b/runtime/logger.go
@@ -85,6 +85,6 @@ type RunenvLoggerWriter struct {
 }
 
 func (r *RunenvLoggerWriter) Write(p []byte) (n int, err error) {
-	r.runenv.RecordNamespaced(r.namespace, p)
+	r.runenv.RecordJsonMetric(r.namespace, p)
 	return len(p), nil
 }

--- a/runtime/logger.go
+++ b/runtime/logger.go
@@ -79,7 +79,12 @@ func (l *logger) Loggers() (*zap.Logger, *zap.SugaredLogger) {
 	return l.logger, l.slogger
 }
 
-// Implement go-metrics.Logger interface
-func (l *logger) Printf(format string, v ...interface{}) {
-	l.slogger.Infof(format, v...)
+type RunenvLoggerWriter struct {
+	runenv    *RunEnv
+	namespace string
+}
+
+func (r *RunenvLoggerWriter) Write(p []byte) (n int, err error) {
+	r.runenv.RecordNamespaced(r.namespace, p)
+	return len(p), nil
 }

--- a/runtime/metrics.go
+++ b/runtime/metrics.go
@@ -1,171 +1,62 @@
 package runtime
 
 import (
-	"context"
-	"io"
-	"net/http"
-	"os"
-	"path"
-	"strconv"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rcrowley/go-metrics"
 )
 
 // Type aliases to hide implementation details in the APIs.
 type (
-	Counter   = prometheus.Counter
-	Gauge     = prometheus.Gauge
-	Histogram = prometheus.Histogram
-	Summary   = prometheus.Summary
-
-	CounterOpts   = prometheus.CounterOpts
-	GaugeOpts     = prometheus.GaugeOpts
-	HistogramOpts = prometheus.HistogramOpts
-	SummaryOpts   = prometheus.SummaryOpts
-
-	CounterVec   = prometheus.CounterVec
-	GaugeVec     = prometheus.GaugeVec
-	HistogramVec = prometheus.HistogramVec
-	SummaryVec   = prometheus.SummaryVec
+	Counter   = metrics.Counter
+	Gauge     = metrics.Gauge
+	Histogram = metrics.Histogram
+	Meter     = metrics.Meter
+	Timer     = metrics.Timer
+	Sample    = metrics.Sample
+	EWMA      = metrics.EWMA
+	Logger    = metrics.Logger
 )
 
 type Metrics struct {
 	runenv *RunEnv
 }
 
-func (*Metrics) NewCounter(o CounterOpts) Counter {
-	m := prometheus.NewCounter(o)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewCounter(name string) Counter {
+	return metrics.GetOrRegister(name, metrics.NewCounter()).(metrics.Counter)
 }
 
-func (*Metrics) NewGauge(o GaugeOpts) Gauge {
-	m := prometheus.NewGauge(o)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewGauge(name string) Gauge {
+	return metrics.GetOrRegister(name, metrics.NewGauge()).(metrics.Gauge)
 }
 
-func (*Metrics) NewHistogram(o HistogramOpts) Histogram {
-	m := prometheus.NewHistogram(o)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewGaugeFloat64(name string) Gauge {
+	return metrics.GetOrRegister(name, metrics.NewGaugeFloat64()).(metrics.Gauge)
 }
 
-func (*Metrics) NewSummary(o SummaryOpts) Summary {
-	m := prometheus.NewSummary(o)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewHistogram(name string, s metrics.Sample) Histogram {
+	return metrics.GetOrRegister(name, metrics.NewHistogram(s)).(metrics.Histogram)
+}
+func (*Metrics) NewMeter(name string) Meter {
+	return metrics.GetOrRegister(name, metrics.NewMeter()).(metrics.Meter)
 }
 
-func (*Metrics) NewCounterVec(o CounterOpts, labels ...string) *CounterVec {
-	m := prometheus.NewCounterVec(o, labels)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewTimer(name string) Timer {
+	return metrics.GetOrRegister(name, metrics.NewTimer()).(metrics.Timer)
 }
 
-func (*Metrics) NewGaugeVec(o GaugeOpts, labels ...string) *GaugeVec {
-	m := prometheus.NewGaugeVec(o, labels)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewExpDecaySample(name string, reservoirSize int, alpha float64) Sample {
+	return metrics.GetOrRegister(name, metrics.NewExpDecaySample(reservoirSize, alpha)).(metrics.Sample)
 }
 
-func (*Metrics) NewHistogramVec(o HistogramOpts, labels ...string) *HistogramVec {
-	m := prometheus.NewHistogramVec(o, labels)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewUniformSample(name string, reservoirSize int) Sample {
+	return metrics.GetOrRegister(name, metrics.NewUniformSample(reservoirSize)).(metrics.Sample)
 }
 
-func (*Metrics) NewSummaryVec(o SummaryOpts, labels ...string) *SummaryVec {
-	m := prometheus.NewSummaryVec(o, labels)
-	switch err := prometheus.Register(m); err.(type) {
-	case nil, prometheus.AlreadyRegisteredError:
-	default:
-		panic(err)
-	}
-	return m
+func (*Metrics) NewEWMA(name string, alpha float64) EWMA {
+	return metrics.GetOrRegister(name, metrics.NewEWMA(alpha)).(metrics.EWMA)
 }
 
-// HTTPPeriodicSnapshots periodically fetches the snapshots from the given address
-// and outputs them to the out directory. Every file will be in the format timestamp.out.
-func (re *RunEnv) HTTPPeriodicSnapshots(ctx context.Context, addr string, dur time.Duration, outDir string) error {
-	err := os.MkdirAll(path.Join(re.TestOutputsPath, outDir), 0777)
-	if err != nil {
-		return err
-	}
-
-	nextFile := func() (*os.File, error) {
-		timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-		return os.Create(path.Join(re.TestOutputsPath, outDir, timestamp+".out"))
-	}
-
-	go func() {
-		ticker := time.NewTicker(dur)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				func() {
-					req, err := http.NewRequestWithContext(ctx, "GET", addr, nil)
-					if err != nil {
-						re.RecordMessage("error while creating http request: %v", err)
-						return
-					}
-
-					resp, err := http.DefaultClient.Do(req)
-					if err != nil {
-						re.RecordMessage("error while scraping http endpoint: %v", err)
-						return
-					}
-					defer resp.Body.Close()
-
-					file, err := nextFile()
-					if err != nil {
-						re.RecordMessage("error while getting metrics output file: %v", err)
-						return
-					}
-					defer file.Close()
-
-					_, err = io.Copy(file, resp.Body)
-					if err != nil {
-						re.RecordMessage("error while copying data to file: %v", err)
-						return
-					}
-				}()
-			}
-		}
-	}()
-
-	return nil
+func (*Metrics) Log(duration time.Duration, l Logger) {
+	metrics.Log(metrics.DefaultRegistry, duration, l)
 }

--- a/runtime/metrics.go
+++ b/runtime/metrics.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"io"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
@@ -8,14 +9,14 @@ import (
 
 // Type aliases to hide implementation details in the APIs.
 type (
-	Counter   = metrics.Counter
-	Gauge     = metrics.Gauge
-	Histogram = metrics.Histogram
-	Meter     = metrics.Meter
-	Timer     = metrics.Timer
-	Sample    = metrics.Sample
-	EWMA      = metrics.EWMA
-	Logger    = metrics.Logger
+	Counter      = metrics.Counter
+	EWMA         = metrics.EWMA
+	Gauge        = metrics.Gauge
+	GaugeFloat64 = metrics.GaugeFloat64
+	Histogram    = metrics.Histogram
+	Meter        = metrics.Meter
+	Sample       = metrics.Sample
+	Timer        = metrics.Timer
 )
 
 type Metrics struct {
@@ -26,37 +27,46 @@ func (*Metrics) NewCounter(name string) Counter {
 	return metrics.GetOrRegister(name, metrics.NewCounter()).(metrics.Counter)
 }
 
+func (*Metrics) NewEWMA(name string, alpha float64) EWMA {
+	return metrics.GetOrRegister(name, metrics.NewEWMA(alpha)).(metrics.EWMA)
+}
+
 func (*Metrics) NewGauge(name string) Gauge {
 	return metrics.GetOrRegister(name, metrics.NewGauge()).(metrics.Gauge)
 }
 
-func (*Metrics) NewGaugeFloat64(name string) Gauge {
-	return metrics.GetOrRegister(name, metrics.NewGaugeFloat64()).(metrics.Gauge)
+func (*Metrics) NewGaugeFloat64(name string) GaugeFloat64 {
+	return metrics.GetOrRegister(name, metrics.NewGaugeFloat64()).(metrics.GaugeFloat64)
+}
+
+func (*Metrics) NewFunctionalGauge(f func() int64) Gauge {
+	return metrics.NewFunctionalGauge(f)
+}
+
+func (*Metrics) NewFunctionalGaugeFloat64(f func() float64) GaugeFloat64 {
+	return metrics.NewFunctionalGaugeFloat64(f)
 }
 
 func (*Metrics) NewHistogram(name string, s metrics.Sample) Histogram {
 	return metrics.GetOrRegister(name, metrics.NewHistogram(s)).(metrics.Histogram)
 }
+
 func (*Metrics) NewMeter(name string) Meter {
 	return metrics.GetOrRegister(name, metrics.NewMeter()).(metrics.Meter)
+}
+
+func (*Metrics) NewExpDecaySample(name string, reservoirSize int, alpha float64) Sample {
+	return metrics.NewExpDecaySample(reservoirSize, alpha)
+}
+
+func (*Metrics) NewUniformSample(reservoirSize int) Sample {
+	return metrics.NewUniformSample(reservoirSize)
 }
 
 func (*Metrics) NewTimer(name string) Timer {
 	return metrics.GetOrRegister(name, metrics.NewTimer()).(metrics.Timer)
 }
 
-func (*Metrics) NewExpDecaySample(name string, reservoirSize int, alpha float64) Sample {
-	return metrics.GetOrRegister(name, metrics.NewExpDecaySample(reservoirSize, alpha)).(metrics.Sample)
-}
-
-func (*Metrics) NewUniformSample(name string, reservoirSize int) Sample {
-	return metrics.GetOrRegister(name, metrics.NewUniformSample(reservoirSize)).(metrics.Sample)
-}
-
-func (*Metrics) NewEWMA(name string, alpha float64) EWMA {
-	return metrics.GetOrRegister(name, metrics.NewEWMA(alpha)).(metrics.EWMA)
-}
-
-func (*Metrics) Log(duration time.Duration, l Logger) {
-	metrics.Log(metrics.DefaultRegistry, duration, l)
+func (*Metrics) WriteJson(duration time.Duration, w io.Writer) {
+	metrics.WriteJSON(metrics.DefaultRegistry, duration, w)
 }

--- a/runtime/output.go
+++ b/runtime/output.go
@@ -184,6 +184,11 @@ func (l *logger) RecordMetric(metric *MetricDefinition, value float64) {
 	l.logger.Info("", zap.Object("event", evt))
 }
 
+// RecordNamespaced records binary data into the log, keyed by the provided namespace
+func (l *logger) RecordNamespaced(namespace string, msg []byte) {
+	l.logger.Info("", zap.Binary(namespace, msg))
+}
+
 // Message prints out an informational message.
 //
 // Deprecated: use RecordMessage.

--- a/runtime/runner.go
+++ b/runtime/runner.go
@@ -132,6 +132,15 @@ func setupHTTPListener(runenv *RunEnv) {
 	}()
 }
 
-func setupMetrics(runenv *RunEnv) {
-	runenv.M().Log(time.Second, runenv.logger)
+func setupMetrics(runenv *RunEnv) (err error) {
+	mfile, err := runenv.CreateRawAsset("metrics.out")
+	if err != nil {
+		runenv.RecordCrash(err)
+		return
+	}
+
+	duration := time.Second
+
+	go runenv.M().WriteJson(duration, mfile)
+	return nil
 }

--- a/runtime/runner.go
+++ b/runtime/runner.go
@@ -133,14 +133,19 @@ func setupHTTPListener(runenv *RunEnv) {
 }
 
 func setupMetrics(runenv *RunEnv) (err error) {
+	// A raw file for writing json data
 	mfile, err := runenv.CreateRawAsset("metrics.out")
 	if err != nil {
 		runenv.RecordCrash(err)
 		return
 	}
 
+	lw := &RunenvLoggerWriter{runenv, "metrics"}
+
+	w := io.MultiWriter(mfile, lw)
+
 	duration := time.Second
 
-	go runenv.M().WriteJson(duration, mfile)
+	go runenv.M().WriteJson(duration, w)
 	return nil
 }

--- a/runtime/runner.go
+++ b/runtime/runner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"net/http"
 	_ "net/http/pprof"
@@ -48,6 +49,7 @@ func Invoke(tc TestCaseFn) {
 	defer runenv.Close()
 
 	setupHTTPListener(runenv)
+	setupMetrics(runenv)
 
 	runenv.RecordStart()
 
@@ -128,4 +130,8 @@ func setupHTTPListener(runenv *RunEnv) {
 	go func() {
 		_ = http.Serve(l, nil)
 	}()
+}
+
+func setupMetrics(runenv *RunEnv) {
+	runenv.M().Log(time.Second, runenv.logger)
 }


### PR DESCRIPTION
fix: https://github.com/testground/testground/issues/909

Similarly to the old prometheus metrics, I have placed the metrics namedpaced under runenv.M()
The metrics are output once every second.

go-metrics has a [Log()](https://github.com/rcrowley/go-metrics/blob/master/log.go#L7) method which accepts a logger, however the output is human-readable rather than machine-readable. This is clearly not what we want.

The simple way to write logs to metrics.out in json format is simply to open a Writer and write to it. In order to get zap logging to work, I added a simple Writer which writes to the zap log.

I think we don't need or want both. I would, I think, ditch the zap logging and keep the metrics.log output, @raulk what do you think?

