### PR TITLE
redesign network APIs.

### DIFF
--- a/network/client.go
+++ b/network/client.go
@@ -1,0 +1,97 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/testground/sdk-go/runtime"
+	"github.com/testground/sdk-go/sync"
+)
+
+const (
+	// magic values that we monitor on the Testground runner side to detect when Testground
+	// testplan instances are initialised and at the stage of actually running a test
+	// check cluster_k8s.go for more information
+	InitialisationSuccessful = "network initialisation successful"
+	InitialisationFailed     = "network initialisation failed"
+)
+
+type Client struct {
+	runenv *runtime.RunEnv
+	client *sync.Client
+}
+
+// NewClient returns a new network client. Use this client to request network
+// changes, such as setting latencies, jitter, packet loss, connectedness, etc.
+func NewClient(client *sync.Client, runenv *runtime.RunEnv) *Client {
+	return &Client{
+		runenv: runenv,
+		client: client,
+	}
+}
+
+// WaitNetworkInitialized waits for the sidecar to initialize the network, if
+// the sidecar is enabled. If not, it returns immediately.
+func (c *Client) WaitNetworkInitialized(ctx context.Context) error {
+	if c.runenv.TestSidecar {
+		err := <-c.client.MustBarrier(ctx, "network-initialized", c.runenv.TestInstanceCount).C
+		if err != nil {
+			c.runenv.RecordMessage(InitialisationFailed)
+			return fmt.Errorf("failed to initialize network: %w", err)
+		}
+	}
+	c.runenv.RecordMessage(InitialisationSuccessful)
+	return nil
+}
+
+// MustWaitNetworkInitialized calls WaitNetworkInitialized, and panics if it
+// errors. It is suitable to use with runner.Invoke/InvokeMap, as long as
+// this method is called from the main goroutine of the test plan.
+func (c *Client) MustWaitNetworkInitialized(ctx context.Context) {
+	err := c.WaitNetworkInitialized(ctx)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ConfigureNetwork asks the sidecar to configure the network, and returns
+// either when the sidecar signals back to us, or when the context expires.
+func (c *Client) ConfigureNetwork(ctx context.Context, config *Config) (err error) {
+	if !c.runenv.TestSidecar {
+		return fmt.Errorf("failed to configure network; running in a sidecar-less environment")
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("failed to configure network; could not obtain hostname: %w", err)
+	}
+
+	if config.CallbackState == "" {
+		return fmt.Errorf("failed to configure network; no callback state provided")
+	}
+
+	topic := sync.NewTopic("network:"+hostname, &Config{})
+
+	target := config.CallbackTarget
+	if target == 0 {
+		// Fall back to instance count on zero value.
+		target = c.runenv.TestInstanceCount
+	}
+
+	_, err = c.client.PublishAndWait(ctx, topic, config, config.CallbackState, target)
+	if err != nil {
+		err = fmt.Errorf("failed to configure network: %w", err)
+	}
+	return err
+}
+
+// MustConfigureNetwork calls ConfigureNetwork, and panics if it
+// errors. It is suitable to use with runner.Invoke/InvokeMap, as long as
+// this method is called from the main goroutine of the test plan.
+func (c *Client) MustConfigureNetwork(ctx context.Context, config *Config) {
+	err := c.ConfigureNetwork(ctx, config)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
I've been wanting to do this for a long time.

* The network configuration APIs were too barebones and exposed the internals of the sync service to developers -- leading to a subpar DX.
  * The new `netclient.ConfigureNetwork()` provides the porcelain to deal with network configuration in a single call, encapsulating the sync operations required to do this.
* The network configuration APIs were inside the `sync` package. This made sense before, when each sdk package as a module of its own, and we didn't want to add YAM (yet another module). This is no longer the case, so it's a good time to spin the network API into its own package.
* I've migrated the network and example plans to this new version of the SDK: https://github.com/testground/testground/pull/942.