### PR TITLE
tests: fix races.

### DIFF
--- a/runtime/influxdb_batch_test.go
+++ b/runtime/influxdb_batch_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 func TestLengthBatching(t *testing.T) {
-	re, cleanup := RandomTestRunEnv(t)
+	runenv, cleanup := RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	tc := &testClient{}
-	b := newBatcher(re, tc, 16, 24*time.Hour)
+	b := newBatcher(runenv, tc, 16, 24*time.Hour)
 
 	writePoints(t, b, 0, 36)
 
@@ -37,11 +38,12 @@ func TestLengthBatching(t *testing.T) {
 }
 
 func TestIntervalBatching(t *testing.T) {
-	re, cleanup := RandomTestRunEnv(t)
+	runenv, cleanup := RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	tc := &testClient{}
-	b := newBatcher(re, tc, 1000, 500*time.Millisecond)
+	b := newBatcher(runenv, tc, 1000, 500*time.Millisecond)
 
 	writePoints(t, b, 0, 10)
 
@@ -62,8 +64,9 @@ func TestIntervalBatching(t *testing.T) {
 }
 
 func TestBatchFailure(t *testing.T) {
-	re, cleanup := RandomTestRunEnv(t)
+	runenv, cleanup := RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	test := func(b *batcher) func(t *testing.T) {
 		tc := &testClient{}
@@ -107,12 +110,12 @@ func TestBatchFailure(t *testing.T) {
 		}
 	}
 
-	t.Run("batches_by_length", test(newBatcher(re, nil, 10, 24*time.Hour,
+	t.Run("batches_by_length", test(newBatcher(runenv, nil, 10, 24*time.Hour,
 		retry.Attempts(3),
 		retry.Delay(100*time.Millisecond),
 	)))
 
-	t.Run("batches_by_time", test(newBatcher(re, nil, 10, 100*time.Millisecond,
+	t.Run("batches_by_time", test(newBatcher(runenv, nil, 10, 100*time.Millisecond,
 		retry.Attempts(3),
 		retry.Delay(100*time.Millisecond),
 	)))

--- a/runtime/metrics_api.go
+++ b/runtime/metrics_api.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -110,6 +111,9 @@ func (m *MetricsApi) background() {
 		case f := <-m.freqChangeCh:
 			m.freq = f
 			resetTicker(f)
+
+		case <-context.Background().Done():
+			return
 
 		case <-m.doneCh:
 			return

--- a/runtime/metrics_api.go
+++ b/runtime/metrics_api.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -111,9 +110,6 @@ func (m *MetricsApi) background() {
 		case f := <-m.freqChangeCh:
 			m.freq = f
 			resetTicker(f)
-
-		case <-context.Background().Done():
-			return
 
 		case <-m.doneCh:
 			return

--- a/sync/barrier_test.go
+++ b/sync/barrier_test.go
@@ -16,6 +16,7 @@ func TestBarrier(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {
@@ -49,6 +50,7 @@ func TestBarrierBeyondTarget(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {
@@ -77,6 +79,7 @@ func TestBarrierZero(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {
@@ -104,6 +107,7 @@ func TestBarrierCancel(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {
@@ -132,6 +136,7 @@ func TestBarrierDeadline(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {
@@ -162,6 +167,7 @@ func TestSignalAndWait(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {
@@ -185,6 +191,7 @@ func TestSignalAndWait(t *testing.T) {
 func TestSignalAndWaitTimeout(t *testing.T) {
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(context.Background(), runenv)
 	if err != nil {

--- a/sync/gc_test.go
+++ b/sync/gc_test.go
@@ -19,6 +19,7 @@ func TestGC(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	client, err := NewBoundClient(ctx, runenv)
 	if err != nil {

--- a/sync/generic_client_test.go
+++ b/sync/generic_client_test.go
@@ -30,6 +30,7 @@ func TestGenericClientRunEnv(t *testing.T) {
 
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	bclient, err := NewBoundClient(ctx, runenv)
 	if err != nil {

--- a/sync/topic_test.go
+++ b/sync/topic_test.go
@@ -26,6 +26,7 @@ func TestSubscribeAfterAllPublished(t *testing.T) {
 	)
 
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -73,6 +74,7 @@ func TestSubscribeFirstConcurrentWrites(t *testing.T) {
 	)
 
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -130,6 +132,7 @@ func TestSubscriptionConcurrentPublishersSubscribers(t *testing.T) {
 	)
 
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -178,8 +181,8 @@ func TestSubscriptionConcurrentPublishersSubscribers(t *testing.T) {
 
 func TestSubscriptionValidation(t *testing.T) {
 	runenv, cleanup := runtime.RandomTestRunEnv(t)
-
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -221,6 +224,7 @@ func TestSequenceOnWrite(t *testing.T) {
 	)
 
 	t.Cleanup(cleanup)
+	defer runenv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Fixes https://github.com/testground/sdk-go/issues/6.

Many tests weren't closing the runenv, so we ended up accumulating goroutines that all tried to read the memstats at once, causing the race.

I've also added an extra ch recv in the background goroutine to yield when the background context is cancelled.