### PR TITLE
fix histogram.Mean deadlock

### DIFF
--- a/runtime/resetting_histogram.go
+++ b/runtime/resetting_histogram.go
@@ -217,7 +217,7 @@ func (t *resettingHistogramSnapshot) Variance() float64 {
 		return 0.0
 	}
 
-	m := t.Mean()
+	m := t._mean()
 	var sum float64
 	for _, v := range t.values {
 		d := float64(v) - m
@@ -276,6 +276,10 @@ func (t *resettingHistogramSnapshot) Mean() float64 {
 	t.Lock()
 	defer t.Unlock()
 
+	return t._mean()
+}
+
+func (t *resettingHistogramSnapshot) _mean() float64 {
 	if !t.calculated {
 		_ = t.calc([]float64{})
 	}


### PR DESCRIPTION
`Mean` is called not just by users, but also by `Variance` and `StdDev`, which currently results in deadlocks.

So I am extracting the inner function into one that is not behind a mutex.