### PR TITLE
introduce notifications

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -36,7 +36,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -49,7 +48,6 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -87,7 +85,6 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -118,7 +115,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -149,7 +145,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343 h1:00ohfJ4K98s3m6BGUoBd8nyfp4Yl0GoIKvw5abItTjI=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -183,7 +178,6 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f h1:kDxGY2VmgABOe55qheT/TFqUMtcTHnomIPS1iv3G4Ms=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -204,7 +198,6 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=

--- a/network/client.go
+++ b/network/client.go
@@ -18,32 +18,29 @@ const (
 )
 
 type Client struct {
-	runenv *runtime.RunEnv
-	client sync.Client
+	runenv     *runtime.RunEnv
+	syncClient sync.Client
 }
 
 // NewClient returns a new network client. Use this client to request network
 // changes, such as setting latencies, jitter, packet loss, connectedness, etc.
-func NewClient(client sync.Client, runenv *runtime.RunEnv) *Client {
+func NewClient(syncClient sync.Client, runenv *runtime.RunEnv) *Client {
 	return &Client{
-		runenv: runenv,
-		client: client,
+		runenv:     runenv,
+		syncClient: syncClient,
 	}
 }
 
 // WaitNetworkInitialized waits for the sidecar to initialize the network, if
 // the sidecar is enabled. If not, it returns immediately.
 func (c *Client) WaitNetworkInitialized(ctx context.Context) error {
-	synccl, ok := c.client.(*sync.DefaultClient)
-	if ok {
-		err := synccl.SignalEvent(ctx, &runtime.Notification{GroupID: c.runenv.TestGroupID, Scope: "stage", EventType: "entry", StageName: "network-initialized"})
-		if err != nil {
-			return err
-		}
+	err := c.syncClient.SignalEvent(ctx, &runtime.Notification{GroupID: c.runenv.TestGroupID, Scope: "stage", EventType: "entry", StageName: "network-initialized"})
+	if err != nil {
+		return err
 	}
 
 	if c.runenv.TestSidecar {
-		err := <-c.client.MustBarrier(ctx, "network-initialized", c.runenv.TestInstanceCount).C
+		err := <-c.syncClient.MustBarrier(ctx, "network-initialized", c.runenv.TestInstanceCount).C
 		if err != nil {
 			c.runenv.RecordMessage(InitialisationFailed)
 			return fmt.Errorf("failed to initialize network: %w", err)
@@ -51,11 +48,9 @@ func (c *Client) WaitNetworkInitialized(ctx context.Context) error {
 	}
 	c.runenv.RecordMessage(InitialisationSuccessful)
 
-	if ok {
-		err := synccl.SignalEvent(ctx, &runtime.Notification{GroupID: c.runenv.TestGroupID, Scope: "stage", EventType: "exit", StageName: "network-initialized"})
-		if err != nil {
-			return err
-		}
+	err = c.syncClient.SignalEvent(ctx, &runtime.Notification{GroupID: c.runenv.TestGroupID, Scope: "stage", EventType: "exit", StageName: "network-initialized"})
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -97,7 +92,7 @@ func (c *Client) ConfigureNetwork(ctx context.Context, config *Config) (err erro
 		target = c.runenv.TestInstanceCount
 	}
 
-	_, err = c.client.PublishAndWait(ctx, topic, config, config.CallbackState, target)
+	_, err = c.syncClient.PublishAndWait(ctx, topic, config, config.CallbackState, target)
 	if err != nil {
 		err = fmt.Errorf("failed to configure network: %w", err)
 	}

--- a/network/client.go
+++ b/network/client.go
@@ -34,7 +34,7 @@ func NewClient(client sync.Client, runenv *runtime.RunEnv) *Client {
 // WaitNetworkInitialized waits for the sidecar to initialize the network, if
 // the sidecar is enabled. If not, it returns immediately.
 func (c *Client) WaitNetworkInitialized(ctx context.Context) error {
-	synccl, ok := c.client.(*sync.Client)
+	synccl, ok := c.client.(*sync.DefaultClient)
 	if ok {
 		err := synccl.SignalEvent(ctx, &runtime.Notification{GroupID: c.runenv.TestGroupID, Scope: "stage", EventType: "entry", StageName: "network-initialized"})
 		if err != nil {

--- a/peek/peek.go
+++ b/peek/peek.go
@@ -24,43 +24,7 @@ var DefaultRedisOpts = redis.Options{
 	MaxConnAge:         2 * time.Minute,
 }
 
-//func MonitorBarriers(rp *runtime.RunParams) {
-//host := "testground-infra-redis-headless"
-//port := 6379
-//opts := DefaultRedisOpts
-//opts.Addr = fmt.Sprintf("%s:%d", host, port)
-//client := redis.NewClient(&opts)
-
-//key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
-
-//members, err := client.SMembers(key).Result()
-//if err != nil {
-//panic(err)
-//}
-
-//spew.Dump(members)
-
-////vals, err := client.MGet(key).Result()
-////if err != nil {
-////panic(err)
-////}
-
-////v := vals[0]
-
-////if v == nil {
-////return
-////}
-
-////curr, err := strconv.ParseInt(v.(string), 10, 64)
-////if err != nil {
-////panic(err)
-////}
-
-////fmt.Println(curr)
-////spew.Dump(curr)
-//}
-
-func MonitorBarriers(rp *runtime.RunParams, lastid string) (retlastid string, nots []*runtime.Notification) {
+func MonitorEvents(rp *runtime.RunParams, lastid string) (retlastid string, nots []*runtime.Notification) {
 	host := "testground-infra-redis-headless"
 	port := 6379
 	opts := DefaultRedisOpts

--- a/peek/peek.go
+++ b/peek/peek.go
@@ -1,0 +1,102 @@
+package peek
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis/v7"
+	"github.com/testground/sdk-go/runtime"
+	"github.com/testground/sdk-go/sync"
+)
+
+var DefaultRedisOpts = redis.Options{
+	MinIdleConns:       2,               // allow the pool to downsize to 0 conns.
+	PoolSize:           5,               // one for subscriptions, one for nonblocking operations.
+	PoolTimeout:        3 * time.Minute, // amount of time a waiter will wait for a conn to become available.
+	MaxRetries:         30,
+	MinRetryBackoff:    1 * time.Second,
+	MaxRetryBackoff:    3 * time.Second,
+	DialTimeout:        10 * time.Second,
+	ReadTimeout:        10 * time.Second,
+	WriteTimeout:       10 * time.Second,
+	IdleCheckFrequency: 30 * time.Second,
+	MaxConnAge:         2 * time.Minute,
+}
+
+//func MonitorBarriers(rp *runtime.RunParams) {
+//host := "testground-infra-redis-headless"
+//port := 6379
+//opts := DefaultRedisOpts
+//opts.Addr = fmt.Sprintf("%s:%d", host, port)
+//client := redis.NewClient(&opts)
+
+//key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
+
+//members, err := client.SMembers(key).Result()
+//if err != nil {
+//panic(err)
+//}
+
+//spew.Dump(members)
+
+////vals, err := client.MGet(key).Result()
+////if err != nil {
+////panic(err)
+////}
+
+////v := vals[0]
+
+////if v == nil {
+////return
+////}
+
+////curr, err := strconv.ParseInt(v.(string), 10, 64)
+////if err != nil {
+////panic(err)
+////}
+
+////fmt.Println(curr)
+////spew.Dump(curr)
+//}
+
+func MonitorBarriers(rp *runtime.RunParams, lastid string) (retlastid string, nots []*runtime.Notification) {
+	host := "testground-infra-redis-headless"
+	port := 6379
+	opts := DefaultRedisOpts
+	opts.Addr = fmt.Sprintf("%s:%d", host, port)
+	client := redis.NewClient(&opts)
+
+	key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
+
+	args := new(redis.XReadArgs)
+	args.Streams = []string{key, lastid}
+	args.Block = 1 * time.Second
+	args.Count = 10000
+
+	streams, err := client.XRead(args).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return lastid, nil
+		}
+
+		panic(err)
+	}
+
+	for _, xr := range streams {
+		for _, msg := range xr.Messages {
+			payload := msg.Values[sync.RedisPayloadKey].(string)
+
+			notification := &runtime.Notification{}
+			err := json.Unmarshal([]byte(payload), notification)
+			if err != nil {
+				panic(err)
+			}
+
+			nots = append(nots, notification)
+
+			retlastid = msg.ID
+		}
+	}
+	return
+}

--- a/peek/peek.go
+++ b/peek/peek.go
@@ -32,6 +32,7 @@ func MonitorEvents(rp *runtime.RunParams, lastid string) (retlastid string, nots
 	client := redis.NewClient(&opts)
 
 	key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
+	fmt.Println(key)
 
 	args := new(redis.XReadArgs)
 	args.Streams = []string{key, lastid}
@@ -44,7 +45,9 @@ func MonitorEvents(rp *runtime.RunParams, lastid string) (retlastid string, nots
 			return lastid, nil
 		}
 
-		panic(err)
+		fmt.Println(err.Error())
+		return
+		//panic(err)
 	}
 
 	for _, xr := range streams {

--- a/peek/peek.go
+++ b/peek/peek.go
@@ -32,7 +32,6 @@ func MonitorEvents(rp *runtime.RunParams, lastid string) (retlastid string, nots
 	client := redis.NewClient(&opts)
 
 	key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
-	fmt.Println(key)
 
 	args := new(redis.XReadArgs)
 	args.Streams = []string{key, lastid}
@@ -45,9 +44,7 @@ func MonitorEvents(rp *runtime.RunParams, lastid string) (retlastid string, nots
 			return lastid, nil
 		}
 
-		fmt.Println(err.Error())
-		return
-		//panic(err)
+		panic(err)
 	}
 
 	for _, xr := range streams {

--- a/run/init_context.go
+++ b/run/init_context.go
@@ -59,6 +59,8 @@ func (ic *InitContext) init(runenv *runtime.RunEnv) {
 		runenv:     runenv,
 	}
 
+	runenv.AttachSyncClient(client)
+
 	runenv.RecordMessage("claimed sequence numbers; global=%d, group(%s)=%d", ic.GlobalSeq, runenv.TestGroupID, ic.GroupSeq)
 }
 

--- a/run/invoker.go
+++ b/run/invoker.go
@@ -151,8 +151,7 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 		case InitializedTestCaseFn:
 			ic := new(InitContext)
 			ic.init(runenv)
-			//defer ic.close()
-			closer = ic.close
+			closer = ic.close // we want to close the InitContext after having calld RecordSuccess or RecordFailure
 			errCh <- f(runenv, ic)
 		default:
 			msg := fmt.Sprintf("unexpected function passed to Invoke*; expected types: TestCaseFn, InitializedTestCaseFn; was: %T", f)

--- a/run/invoker.go
+++ b/run/invoker.go
@@ -85,6 +85,13 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 
 	runenv.RecordStart()
 
+	var closer func()
+	defer func() {
+		if closer != nil {
+			closer()
+		}
+	}()
+
 	var err error
 	errfile, err := runenv.CreateRawAsset("run.err")
 	if err != nil {
@@ -144,7 +151,8 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 		case InitializedTestCaseFn:
 			ic := new(InitContext)
 			ic.init(runenv)
-			defer ic.close()
+			//defer ic.close()
+			closer = ic.close
 			errCh <- f(runenv, ic)
 		default:
 			msg := fmt.Sprintf("unexpected function passed to Invoke*; expected types: TestCaseFn, InitializedTestCaseFn; was: %T", f)

--- a/runtime/notification.go
+++ b/runtime/notification.go
@@ -1,0 +1,10 @@
+package runtime
+
+type Notification struct {
+	InstanceID   string `json:"instance_id"`
+	GroupID      string `json:"group_id"`
+	GlobalSeqNum string `json:"global_seq_num"`
+	EventType    string `json:"event_type"` // start, end, failure, crash, entry, exit for stages
+	Scope        string `json:"scope"`      // test case, test case stage
+	StageName    string `json:"stage_name"`
+}

--- a/runtime/notification.go
+++ b/runtime/notification.go
@@ -1,10 +1,10 @@
 package runtime
 
 type Notification struct {
-	InstanceID   string `json:"instance_id"`
-	GroupID      string `json:"group_id"`
-	GlobalSeqNum string `json:"global_seq_num"`
-	EventType    string `json:"event_type"` // start, end, failure, crash, entry, exit for stages
-	Scope        string `json:"scope"`      // test case, test case stage
-	StageName    string `json:"stage_name"`
+	//InstanceID   string `json:"instance_id"`
+	//GlobalSeqNum string `json:"global_seq_num"`
+	GroupID   string `json:"group_id"`
+	EventType string `json:"event_type"` // start, end, failure, crash, entry, exit for stages
+	Scope     string `json:"scope"`      // test case, test case stage
+	StageName string `json:"stage_name"`
 }

--- a/runtime/notification.go
+++ b/runtime/notification.go
@@ -1,8 +1,6 @@
 package runtime
 
 type Notification struct {
-	//InstanceID   string `json:"instance_id"`
-	//GlobalSeqNum string `json:"global_seq_num"`
 	GroupID   string `json:"group_id"`
 	EventType string `json:"event_type"` // start, end, failure, crash, entry, exit for stages
 	Scope     string `json:"scope"`      // test case, test case stage

--- a/runtime/runenv.go
+++ b/runtime/runenv.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"os"
 	gosync "sync"
 	"time"
@@ -32,6 +33,7 @@ type RunEnv struct {
 
 	logger  *zap.Logger
 	metrics *Metrics
+	synccl  SyncClient
 
 	wg        gosync.WaitGroup
 	closeCh   chan struct{}
@@ -68,6 +70,14 @@ func NewRunEnv(params RunParams) *RunEnv {
 	re.metrics = newMetrics(re)
 
 	return re
+}
+
+type SyncClient interface {
+	SignalEvent(context.Context, interface{}) error
+}
+
+func (re *RunEnv) AttachSyncClient(synccl SyncClient) {
+	re.synccl = synccl
 }
 
 // R returns a metrics object for results.

--- a/runtime/runenv.go
+++ b/runtime/runenv.go
@@ -31,9 +31,9 @@ var (
 type RunEnv struct {
 	RunParams
 
-	logger     *zap.Logger
-	metrics    *Metrics
-	syncClient SyncClient
+	logger        *zap.Logger
+	metrics       *Metrics
+	signalEventer SignalEventer
 
 	wg        gosync.WaitGroup
 	closeCh   chan struct{}
@@ -72,12 +72,12 @@ func NewRunEnv(params RunParams) *RunEnv {
 	return re
 }
 
-type SyncClient interface {
+type SignalEventer interface {
 	SignalEvent(context.Context, interface{}) error
 }
 
-func (re *RunEnv) AttachSyncClient(sc SyncClient) {
-	re.syncClient = sc
+func (re *RunEnv) AttachSyncClient(se SignalEventer) {
+	re.signalEventer = se
 }
 
 // R returns a metrics object for results.

--- a/runtime/runenv.go
+++ b/runtime/runenv.go
@@ -31,9 +31,9 @@ var (
 type RunEnv struct {
 	RunParams
 
-	logger  *zap.Logger
-	metrics *Metrics
-	synccl  SyncClient
+	logger     *zap.Logger
+	metrics    *Metrics
+	syncClient SyncClient
 
 	wg        gosync.WaitGroup
 	closeCh   chan struct{}
@@ -76,8 +76,8 @@ type SyncClient interface {
 	SignalEvent(context.Context, interface{}) error
 }
 
-func (re *RunEnv) AttachSyncClient(synccl SyncClient) {
-	re.synccl = synccl
+func (re *RunEnv) AttachSyncClient(sc SyncClient) {
+	re.syncClient = sc
 }
 
 // R returns a metrics object for results.

--- a/runtime/runenv_events.go
+++ b/runtime/runenv_events.go
@@ -122,8 +122,8 @@ func (re *RunEnv) RecordSuccess() {
 	re.logger.Info("", zap.Object("event", evt))
 	re.metrics.recordEvent(&evt)
 
-	if re.syncClient != nil {
-		_ = re.syncClient.SignalEvent(context.Background(), &Notification{GroupID: re.RunParams.TestGroupID, Scope: "test-case", EventType: "outcome-ok"})
+	if re.signalEventer != nil {
+		_ = re.signalEventer.SignalEvent(context.Background(), &Notification{GroupID: re.RunParams.TestGroupID, Scope: "test-case", EventType: "outcome-ok"})
 	}
 }
 

--- a/runtime/runenv_events.go
+++ b/runtime/runenv_events.go
@@ -122,8 +122,8 @@ func (re *RunEnv) RecordSuccess() {
 	re.logger.Info("", zap.Object("event", evt))
 	re.metrics.recordEvent(&evt)
 
-	if re.synccl != nil {
-		_ = re.synccl.SignalEvent(context.Background(), &Notification{GroupID: re.RunParams.TestGroupID, Scope: "test-case", EventType: "outcome-ok"})
+	if re.syncClient != nil {
+		_ = re.syncClient.SignalEvent(context.Background(), &Notification{GroupID: re.RunParams.TestGroupID, Scope: "test-case", EventType: "outcome-ok"})
 	}
 }
 

--- a/runtime/runenv_events.go
+++ b/runtime/runenv_events.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 
@@ -120,6 +121,10 @@ func (re *RunEnv) RecordSuccess() {
 	}
 	re.logger.Info("", zap.Object("event", evt))
 	re.metrics.recordEvent(&evt)
+
+	if re.synccl != nil {
+		_ = re.synccl.SignalEvent(context.Background(), &Notification{GroupID: re.RunParams.TestGroupID, Scope: "test-case", EventType: "outcome-ok"})
+	}
 }
 
 // RecordFailure records that the calling instance failed with the supplied

--- a/sync/client.go
+++ b/sync/client.go
@@ -65,7 +65,14 @@ type DefaultClient struct {
 //
 // For test plans, a suitable context to pass here is the background context.
 func NewBoundClient(ctx context.Context, runenv *runtime.RunEnv) (*DefaultClient, error) {
-	return newClient(ctx, runenv.SLogger(), func(ctx context.Context) *runtime.RunParams {
+	log := runenv.SLogger()
+
+	rclient, err := redisClient(ctx, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create redis client: %w", err)
+	}
+
+	return newClient(ctx, rclient, log, func(ctx context.Context) *runtime.RunParams {
 		return &runenv.RunParams
 	})
 }
@@ -94,7 +101,16 @@ func MustBoundClient(ctx context.Context, runenv *runtime.RunEnv) *DefaultClient
 // A suitable context to pass here is the background context of the main
 // process.
 func NewGenericClient(ctx context.Context, log *zap.SugaredLogger) (*DefaultClient, error) {
-	return newClient(ctx, log, GetRunParams)
+	rclient, err := redisClient(ctx, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create redis client: %w", err)
+	}
+
+	return newClient(ctx, rclient, log, GetRunParams)
+}
+
+func NewGenericClientWithRedis(ctx context.Context, rclient *redis.Client, log *zap.SugaredLogger) (*DefaultClient, error) {
+	return newClient(ctx, rclient, log, GetRunParams)
 }
 
 // MustGenericClient creates a new generic client by calling NewGenericClient,
@@ -108,19 +124,14 @@ func MustGenericClient(ctx context.Context, log *zap.SugaredLogger) *DefaultClie
 }
 
 // newClient creates a new sync client.
-func newClient(ctx context.Context, log *zap.SugaredLogger, extractor func(ctx context.Context) *runtime.RunParams) (*DefaultClient, error) {
-	rclient, err := redisClient(ctx, log)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create redis client: %w", err)
-	}
-
+func newClient(ctx context.Context, redisClient *redis.Client, log *zap.SugaredLogger, extractor func(ctx context.Context) *runtime.RunParams) (*DefaultClient, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	c := &DefaultClient{
 		ctx:       ctx,
 		cancel:    cancel,
 		log:       log,
 		extractor: extractor,
-		rclient:   rclient,
+		rclient:   redisClient,
 		barrierCh: make(chan *newBarrier),
 		newSubCh:  make(chan *newSubscription),
 	}
@@ -139,7 +150,7 @@ func newClient(ctx context.Context, log *zap.SugaredLogger, extractor func(ctx c
 			for {
 				select {
 				case <-tick.C:
-					stats := rclient.PoolStats()
+					stats := redisClient.PoolStats()
 					log.Debugw("redis pool stats", "stats", stats)
 				case <-ctx.Done():
 					return

--- a/sync/client_inmem.go
+++ b/sync/client_inmem.go
@@ -119,6 +119,10 @@ func (i *inmemClient) SignalEntry(_ context.Context, state State) (after int64, 
 	return v, nil
 }
 
+func (i *inmemClient) SignalEvent(_ context.Context, event interface{}) error {
+	return nil
+}
+
 func (i *inmemClient) Close() error {
 	return nil
 }

--- a/sync/client_state.go
+++ b/sync/client_state.go
@@ -2,6 +2,10 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-redis/redis/v7"
 )
 
 // Barrier sets a barrier on the supplied State that fires when it reaches its
@@ -72,4 +76,31 @@ func (c *DefaultClient) SignalEntry(ctx context.Context, state State) (after int
 
 	c.log.Debugw("new value of state", "key", key, "value", seq)
 	return seq, err
+}
+
+func (c *Client) SignalEvent(ctx context.Context, event interface{}) (err error) {
+	rp := c.extractor(ctx)
+	if rp == nil {
+		return ErrNoRunParameters
+	}
+
+	key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
+
+	ev, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	args := &redis.XAddArgs{
+		Stream: key,
+		ID:     "*",
+		Values: map[string]interface{}{RedisPayloadKey: ev},
+	}
+
+	_, err = c.rclient.XAdd(args).Result()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/sync/client_state.go
+++ b/sync/client_state.go
@@ -78,7 +78,7 @@ func (c *DefaultClient) SignalEntry(ctx context.Context, state State) (after int
 	return seq, err
 }
 
-func (c *Client) SignalEvent(ctx context.Context, event interface{}) (err error) {
+func (c *DefaultClient) SignalEvent(ctx context.Context, event interface{}) (err error) {
 	rp := c.extractor(ctx)
 	if rp == nil {
 		return ErrNoRunParameters

--- a/sync/client_state.go
+++ b/sync/client_state.go
@@ -79,17 +79,20 @@ func (c *DefaultClient) SignalEntry(ctx context.Context, state State) (after int
 }
 
 func (c *DefaultClient) SignalEvent(ctx context.Context, event interface{}) (err error) {
+	c.log.Debugw("inside signal entry")
 	rp := c.extractor(ctx)
 	if rp == nil {
 		return ErrNoRunParameters
 	}
 
 	key := fmt.Sprintf("run:%s:plan:%s:case:%s", rp.TestRun, rp.TestPlan, rp.TestCase)
+	c.log.Debugw("signal entry key", "key", key)
 
 	ev, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
+	c.log.Debugw("signal event marshaled", "key", key)
 
 	args := &redis.XAddArgs{
 		Stream: key,
@@ -101,6 +104,7 @@ func (c *DefaultClient) SignalEvent(ctx context.Context, event interface{}) (err
 	if err != nil {
 		return err
 	}
+	c.log.Debugw("signal event xadded", "key", key)
 
 	return nil
 }

--- a/sync/interface.go
+++ b/sync/interface.go
@@ -25,4 +25,6 @@ type Client interface {
 	MustPublishAndWait(ctx context.Context, topic *Topic, payload interface{}, state State, target int) (seq int64)
 	MustPublishSubscribe(ctx context.Context, topic *Topic, payload interface{}, ch interface{}) (seq int64, sub *Subscription)
 	MustSignalAndWait(ctx context.Context, state State, target int) (seq int64)
+
+	SignalEvent(context.Context, interface{}) error
 }


### PR DESCRIPTION
This PR is introducing a `notification` package in the SDK - a way for the daemon to receive notifications from the `sync service` with respect to events on the test instances.

Notifications' goal is to convey information to the Testground daemon with respect to the:
1. Outcomes of test plan instances
2. Stages passed

When test plans have multiple stages, this functionality will make it easier to determine at which stage a test run blocked and why.

---

TODO:
- [ ] decide on the schema for `notifications`.
- [ ] decide on data structure within Redis to support `notifications`.