### PR TITLE
introduce `sdk.Verbose` flag to enable verbose sdk logging.

### DIFF
--- a/run/invoker.go
+++ b/run/invoker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/testground/sdk-go"
 	"github.com/testground/sdk-go/runtime"
 )
 
@@ -149,7 +150,9 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 
 	_ = rd.Close()
 	<-ioDoneCh
-	runenv.RecordMessage("io closed")
+	if sdk.Verbose {
+		runenv.RecordMessage("io closed")
+	}
 }
 
 func maybeSetupHTTPListener(runenv *runtime.RunEnv) {

--- a/runtime/influxdb_batch.go
+++ b/runtime/influxdb_batch.go
@@ -7,6 +7,8 @@ import (
 	"github.com/avast/retry-go"
 	_ "github.com/influxdata/influxdb1-client"
 	client "github.com/influxdata/influxdb1-client/v2"
+
+	"github.com/testground/sdk-go"
 )
 
 type Batcher interface {
@@ -113,7 +115,9 @@ func (b *batcher) background() {
 				// we are currently sending, wait for the send to finish first.
 				if err := <-b.sendRes; err == nil {
 					b.pending = b.pending[len(b.sending):]
-					b.re.RecordMessage("influxdb: uploaded %d points", len(b.sending))
+					if sdk.Verbose {
+						b.re.RecordMessage("influxdb: uploaded %d points", len(b.sending))
+					}
 				} else {
 					b.re.RecordMessage("influxdb: failed to upload %d points; err: %s", len(b.sending), err)
 				}
@@ -126,7 +130,9 @@ func (b *batcher) background() {
 				go b.send()
 				err = <-b.sendRes
 				if err == nil {
-					b.re.RecordMessage("influxdb: uploaded %d points", len(b.sending))
+					if sdk.Verbose {
+						b.re.RecordMessage("influxdb: uploaded %d points", len(b.sending))
+					}
 				} else {
 					b.re.RecordMessage("influxdb: failed to upload %d points; err: %s", len(b.sending), err)
 				}

--- a/verbose.go
+++ b/verbose.go
@@ -1,0 +1,4 @@
+package sdk
+
+// Verbose indicates whether the logs in verbose mode (default: false).
+var Verbose = false


### PR DESCRIPTION
These log statements were really useful to corroborate that things were working when the feature was brand new, but now they just pollute the output:

```
Jun 30 12:13:14.965643	INFO	327.0015s    MESSAGE << 31d74f390af6 >> influxdb: uploaded 58 points	{"req_id": "a808d495"}
Jun 30 12:13:15.076508	INFO	327.1127s    MESSAGE << 43e77ebc68e1 >> influxdb: uploaded 57 points	{"req_id": "a808d495"}
Jun 30 12:13:15.358772	INFO	327.3948s    MESSAGE << dbf3645ad021 >> influxdb: uploaded 58 points	{"req_id": "a808d495"}
Jun 30 12:13:15.360854	INFO	327.3966s    MESSAGE << 604d2a2b9691 >> influxdb: uploaded 58 points	{"req_id": "a808d495"}
Jun 30 12:13:15.364056	INFO	327.4004s    MESSAGE << 19316bb6727a >> influxdb: uploaded 58 points	{"req_id": "a808d495"}
Jun 30 12:13:15.375212	INFO	327.4115s    MESSAGE << e3a55bb07580 >> influxdb: uploaded 58 points	{"req_id": "a808d495"}
```

Rather than removing them, I'm opting to introduce a global `sdk.Verbose` flag which is `false` by default, and only displaying all those log statements when the user sets it to `true`.