### PR TITLE
make {Initialized}TestCaseFn type aliases.

### DIFF
--- a/run/invoker.go
+++ b/run/invoker.go
@@ -29,7 +29,7 @@ const (
 // invoked. If we were unable to start the listener, this value will be "".
 var HTTPListenAddr string
 
-type TestCaseFn func(env *runtime.RunEnv) error
+type TestCaseFn = func(env *runtime.RunEnv) error
 
 // InitializedTestCaseFn allows users to indicate they want a basic
 // initialization routine to be run before yielding control to the test case
@@ -50,7 +50,7 @@ type TestCaseFn func(env *runtime.RunEnv) error
 // The injected InitContext is a bundle containing the result, and you can use
 // its objects in your test logic. In fact, you don't need to close them
 // (sync client, net client), as the SDK manages that for you.
-type InitializedTestCaseFn func(env *runtime.RunEnv, initCtx *InitContext) error
+type InitializedTestCaseFn = func(env *runtime.RunEnv, initCtx *InitContext) error
 
 // InvokeMap takes a map of test case names and their functions, and calls the
 // matched test case, or panics if the name is unrecognised.

--- a/run/invoker_test.go
+++ b/run/invoker_test.go
@@ -60,18 +60,21 @@ func TestUninitializedInvoke(t *testing.T) {
 		_ = os.Setenv(k, v)
 	}
 
+	await := func(ch chan struct{}) {
+		select {
+		case <-ch:
+		case <-time.After(1 * time.Second):
+			t.Fatal("test function not invoked")
+		}
+	}
+
 	// not using type alias.
 	ch := make(chan struct{})
 	Invoke(func(runenv *runtime.RunEnv) error {
 		close(ch)
 		return nil
 	})
-
-	select {
-	case <-ch:
-	case <-time.After(1 * time.Second):
-		t.Fatal("test function not invoked")
-	}
+	await(ch)
 
 	// using type alias.
 	ch = make(chan struct{})
@@ -79,10 +82,6 @@ func TestUninitializedInvoke(t *testing.T) {
 		close(ch)
 		return nil
 	}))
+	await(ch)
 
-	select {
-	case <-ch:
-	case <-time.After(1 * time.Second):
-		t.Fatal("test function not invoked")
-	}
 }

--- a/run/invoker_test.go
+++ b/run/invoker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
@@ -38,7 +39,7 @@ func TestInitializedInvoke(t *testing.T) {
 	}
 
 	env, cleanup := runtime.RandomTestRunEnv(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	for k, v := range env.ToEnvVars() {
 		_ = os.Setenv(k, v)
@@ -49,4 +50,39 @@ func TestInitializedInvoke(t *testing.T) {
 	Invoke(test)
 	Invoke(test)
 	Invoke(test)
+}
+
+func TestUninitializedInvoke(t *testing.T) {
+	env, cleanup := runtime.RandomTestRunEnv(t)
+	t.Cleanup(cleanup)
+
+	for k, v := range env.ToEnvVars() {
+		_ = os.Setenv(k, v)
+	}
+
+	// not using type alias.
+	ch := make(chan struct{})
+	Invoke(func(runenv *runtime.RunEnv) error {
+		close(ch)
+		return nil
+	})
+
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		t.Fatal("test function not invoked")
+	}
+
+	// using type alias.
+	ch = make(chan struct{})
+	Invoke(TestCaseFn(func(runenv *runtime.RunEnv) error {
+		close(ch)
+		return nil
+	}))
+
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		t.Fatal("test function not invoked")
+	}
 }


### PR DESCRIPTION
Thanks to @hacdias for finding this bug. If you passed an anonymous function `func(*runtime.RunEnv) error` to the `Invoke` methods, we'd panic because we didn't consider it a `TestCaseFn`. Turning these types into aliases removes this footgun.