### PR TITLE
Expose redis client in sync.Client

### DIFF
--- a/sync/client.go
+++ b/sync/client.go
@@ -159,6 +159,17 @@ func (c *DefaultClient) Close() error {
 	return c.rclient.Close()
 }
 
+// RedisClient returns the Redis client that underpins sync.DefaultClient.
+//
+// USE WITH CAUTION.
+//
+// Redis is a shared-memory environment, and use of RedisClient() comes with all the
+// usual multithreding caveats.  Use of this method is discouraged where high-level
+// primitives in the sync package suffice to accomplish the task at hand.
+func (c *DefaultClient) RedisClient() *redis.Client {
+	return c.rclient
+}
+
 // newSubscription is an ancillary type used when creating a new Subscription.
 type newSubscription struct {
 	sub      *Subscription

--- a/sync/interface.go
+++ b/sync/interface.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 	"io"
+
+	"github.com/go-redis/redis/v7"
 )
 
 type Client interface {
@@ -25,4 +27,13 @@ type Client interface {
 	MustPublishAndWait(ctx context.Context, topic *Topic, payload interface{}, state State, target int) (seq int64)
 	MustPublishSubscribe(ctx context.Context, topic *Topic, payload interface{}, ch interface{}) (seq int64, sub *Subscription)
 	MustSignalAndWait(ctx context.Context, state State, target int) (seq int64)
+
+	// RedisClient returns the Redis client that underpins sync.DefaultClient.
+	//
+	// USE WITH CAUTION.
+	//
+	// Redis is a shared-memory environment, and use of RedisClient() comes with all the
+	// usual multithreding caveats.  Use of this method is discouraged where high-level
+	// primitives in the sync package suffice to accomplish the task at hand.
+	RedisClient() *redis.Client
 }


### PR DESCRIPTION
Fixes https://github.com/testground/testground/issues/963 by providing controlled access to `sync.DefaultClient.rclient` via the `RedisClient` method.