### PR TITLE
propagate debug stack when panicing

### DIFF
--- a/run/invoker.go
+++ b/run/invoker.go
@@ -169,7 +169,8 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 		}
 	case p := <-panicHandler:
 		// propagate the panic.
-		panic(p)
+		runenv.RecordCrash(p.DebugStacktrace)
+		panic(p.RecoverObj)
 	}
 }
 

--- a/run/panic.go
+++ b/run/panic.go
@@ -1,8 +1,15 @@
 package run
 
+import "runtime/debug"
+
+type PanicPayload struct {
+	RecoverObj      interface{}
+	DebugStacktrace string
+}
+
 // panicHandler is where the top-level main goroutine panic handler is
 // listening for panics.
-var panicHandler = make(chan interface{})
+var panicHandler = make(chan PanicPayload)
 
 // HandlePanics should be called in a defer at the top of any goroutine that
 // the test plan spawns, so that panics from children goroutine are propagated
@@ -13,5 +20,5 @@ func HandlePanics() {
 	if obj == nil {
 		return
 	}
-	panicHandler <- obj
+	panicHandler <- PanicPayload{obj, string(debug.Stack())}
 }

--- a/runtime/metrics.go
+++ b/runtime/metrics.go
@@ -186,13 +186,18 @@ func (m *Metrics) recordEvent(evt *Event) {
 	}
 
 	// this map copy is terrible; the influxdb v2 SDK makes points mutable.
-	tags := make(map[string]string, len(m.tags)+1)
+	tags := make(map[string]string, len(m.tags)+2)
 	for k, v := range m.tags {
 		tags[k] = v
 	}
 
-	measurement := fmt.Sprintf("events.%s", evt.Type())
-	p, err := client.NewPoint(measurement, tags, nil)
+	fields := map[string]interface{}{
+		"count": 1,
+	}
+
+	tags["event_type"] = evt.Type()
+
+	p, err := client.NewPoint("events", tags, fields)
 	if err != nil {
 		m.re.RecordMessage("failed to create InfluxDB point: %s", err)
 	}

--- a/runtime/runenv_events.go
+++ b/runtime/runenv_events.go
@@ -45,7 +45,7 @@ type StartEvent struct {
 }
 
 func (StartEvent) Type() string {
-	return "StartEvent"
+	return "start_event"
 }
 
 func (s StartEvent) MarshalLogObject(oe zapcore.ObjectEncoder) error {
@@ -57,7 +57,7 @@ type MessageEvent struct {
 }
 
 func (MessageEvent) Type() string {
-	return "MessageEvent"
+	return "message_event"
 }
 
 func (m MessageEvent) MarshalLogObject(oe zapcore.ObjectEncoder) error {
@@ -84,7 +84,7 @@ type FailureEvent struct {
 }
 
 func (FailureEvent) Type() string {
-	return "FailureEvent"
+	return "failure_event"
 }
 
 func (f FailureEvent) MarshalLogObject(oe zapcore.ObjectEncoder) error {
@@ -100,7 +100,7 @@ type CrashEvent struct {
 }
 
 func (CrashEvent) Type() string {
-	return "CrashEvent"
+	return "crash_event"
 }
 
 func (c CrashEvent) MarshalLogObject(oe zapcore.ObjectEncoder) error {
@@ -116,7 +116,7 @@ type StageStartEvent struct {
 }
 
 func (StageStartEvent) Type() string {
-	return "StageStartEvent"
+	return "stage_start_event"
 }
 
 func (s StageStartEvent) MarshalLogObject(oe zapcore.ObjectEncoder) error {
@@ -131,7 +131,7 @@ type StageEndEvent struct {
 }
 
 func (StageEndEvent) Type() string {
-	return "StageEndEvent"
+	return "stage_end_event"
 }
 
 func (s StageEndEvent) MarshalLogObject(oe zapcore.ObjectEncoder) error {


### PR DESCRIPTION
This PR is propagating the debug stack when panicking - currently it is lost at the point we handle panic in the handler and call `panic(p)`, which makes it very hard to debug test plans based on logs.