### PR TITLE
BREAKING: better json encoding + marshalling/unmarshalling

### DIFF
--- a/network/types.go
+++ b/network/types.go
@@ -29,48 +29,48 @@ const (
 // LinkShape defines how traffic should be shaped.
 type LinkShape struct {
 	// Latency is the egress latency
-	Latency time.Duration
+	Latency time.Duration `json:"latency"`
 
 	// Jitter is the egress jitter
-	Jitter time.Duration
+	Jitter time.Duration `json:"jitter"`
 
 	// Bandwidth is egress bytes per second
-	Bandwidth uint64
+	Bandwidth uint64 `json:"bandwidth"`
 
 	// Drop all inbound traffic.
 	// TODO: Not implemented
-	Filter FilterAction
+	Filter FilterAction `json:"filter"`
 
 	// Loss is the egress packet loss (%)
-	Loss float32
+	Loss float32 `json:"loss"`
 
 	// Corrupt is the egress packet corruption probability (%)
-	Corrupt float32
+	Corrupt float32 `json:"corrupt"`
 
 	// Corrupt is the egress packet corruption correlation (%)
-	CorruptCorr float32
+	CorruptCorr float32 `json:"corruptCorr"`
 
 	// Reorder is the probability that an egress packet will be reordered (%)
 	//
 	// Reordered packets will skip the latency delay and be sent
 	// immediately. You must specify a non-zero Latency for this option to
 	// make sense.
-	Reorder float32
+	Reorder float32 `json:"reorder"`
 
 	// ReorderCorr is the egress packet reordering correlation (%)
-	ReorderCorr float32
+	ReorderCorr float32 `json:"reorderCorr"`
 
 	// Duplicate is the percentage of packets that are duplicated (%)
-	Duplicate float32
+	Duplicate float32 `json:"duplicate"`
 
 	// DuplicateCorr is the correlation between egress packet duplication (%)
-	DuplicateCorr float32
+	DuplicateCorr float32 `json:"duplicateCorr"`
 }
 
 // LinkRule applies a LinkShape to a subnet.
 type LinkRule struct {
 	LinkShape
-	Subnet net.IPNet
+	Subnet net.IPNet `json:"subnet"`
 }
 
 // RoutingPolicyType defines a certain routing policy to a network.
@@ -84,7 +84,7 @@ const (
 // NetworkConfig specifies how a node's network should be configured.
 type Config struct {
 	// Network is the name of the network to configure
-	Network string
+	Network string `json:"network"`
 
 	// IPv4 and IPv6 set the IP addresses of this network device. If
 	// unspecified, the sidecar will leave them alone.
@@ -97,21 +97,21 @@ type Config struct {
 	IPv4, IPv6 *net.IPNet
 
 	// Enable enables this network device.
-	Enable bool
+	Enable bool `json:"enable"`
 
 	// Default is the default link shaping rule.
-	Default LinkShape
+	Default LinkShape `json:"default"`
 
 	// Rules defines how traffic should be shaped to different subnets.
 	//
 	// TODO: This is not implemented.
-	Rules []LinkRule
+	Rules []LinkRule `json:"rules"`
 
 	// CallbackState will be signalled when the link changes are applied.
 	//
 	// Nodes can use the same state to wait for _all_ or a subset of nodes to
 	// enter the desired network state. See CallbackTarget.
-	CallbackState sync.State `json:"State"`
+	CallbackState sync.State `json:"callbackState"`
 
 	// CallbackTarget is the amount of instances that will have needed to signal
 	// on the Callback state to consider the configuration operation a success.
@@ -123,5 +123,5 @@ type Config struct {
 	// RoutingPolicy defines the data routing policy of a certain node. This affects
 	// external networks other than the network 'Default', e.g., external Internet
 	// access.
-	RoutingPolicy RoutingPolicyType
+	RoutingPolicy RoutingPolicyType `json:"routingPolicy"`
 }

--- a/network/types.go
+++ b/network/types.go
@@ -2,9 +2,9 @@ package network
 
 import (
 	"fmt"
-	"net"
 	"time"
 
+	"github.com/testground/sdk-go/ptypes"
 	"github.com/testground/sdk-go/sync"
 )
 
@@ -48,7 +48,7 @@ type LinkShape struct {
 	Corrupt float32 `json:"corrupt"`
 
 	// Corrupt is the egress packet corruption correlation (%)
-	CorruptCorr float32 `json:"corruptCorr"`
+	CorruptCorr float32 `json:"corrupt_corr"`
 
 	// Reorder is the probability that an egress packet will be reordered (%)
 	//
@@ -58,19 +58,19 @@ type LinkShape struct {
 	Reorder float32 `json:"reorder"`
 
 	// ReorderCorr is the egress packet reordering correlation (%)
-	ReorderCorr float32 `json:"reorderCorr"`
+	ReorderCorr float32 `json:"reorder_corr"`
 
 	// Duplicate is the percentage of packets that are duplicated (%)
 	Duplicate float32 `json:"duplicate"`
 
 	// DuplicateCorr is the correlation between egress packet duplication (%)
-	DuplicateCorr float32 `json:"duplicateCorr"`
+	DuplicateCorr float32 `json:"duplicate_corr"`
 }
 
 // LinkRule applies a LinkShape to a subnet.
 type LinkRule struct {
 	LinkShape
-	Subnet net.IPNet `json:"subnet"`
+	Subnet ptypes.IPNet `json:"subnet"`
 }
 
 // RoutingPolicyType defines a certain routing policy to a network.
@@ -94,7 +94,7 @@ type Config struct {
 	// and shouldn't be used by the test.
 	//
 	// TODO: IPv6 is currently not supported.
-	IPv4, IPv6 *net.IPNet
+	IPv4, IPv6 *ptypes.IPNet
 
 	// Enable enables this network device.
 	Enable bool `json:"enable"`
@@ -111,7 +111,7 @@ type Config struct {
 	//
 	// Nodes can use the same state to wait for _all_ or a subset of nodes to
 	// enter the desired network state. See CallbackTarget.
-	CallbackState sync.State `json:"callbackState"`
+	CallbackState sync.State `json:"callback_state"`
 
 	// CallbackTarget is the amount of instances that will have needed to signal
 	// on the Callback state to consider the configuration operation a success.
@@ -123,5 +123,5 @@ type Config struct {
 	// RoutingPolicy defines the data routing policy of a certain node. This affects
 	// external networks other than the network 'Default', e.g., external Internet
 	// access.
-	RoutingPolicy RoutingPolicyType `json:"routingPolicy"`
+	RoutingPolicy RoutingPolicyType `json:"routing_policy"`
 }

--- a/ptypes/ipnet.go
+++ b/ptypes/ipnet.go
@@ -1,0 +1,36 @@
+package ptypes
+
+import (
+	"encoding/json"
+	"net"
+)
+
+type IPNet struct {
+	net.IPNet
+}
+
+func (i IPNet) MarshalJSON() ([]byte, error) {
+	if len(i.IPNet.IP) == 0 {
+		return json.Marshal("")
+	}
+	return json.Marshal(i.String())
+}
+
+func (i *IPNet) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	if s == "" {
+		return nil
+	}
+
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return err
+	}
+
+	i.IPNet = *ipnet
+	return nil
+}

--- a/runtime/runparams.go
+++ b/runtime/runparams.go
@@ -10,37 +10,8 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/testground/sdk-go/ptypes"
 )
-
-type IPNet struct {
-	net.IPNet
-}
-
-func (i IPNet) MarshalJSON() ([]byte, error) {
-	if len(i.IPNet.IP) == 0 {
-		return json.Marshal("")
-	}
-	return json.Marshal(i.String())
-}
-
-func (i *IPNet) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-
-	if s == "" {
-		return nil
-	}
-
-	_, ipnet, err := net.ParseCIDR(s)
-	if err != nil {
-		return err
-	}
-
-	i.IPNet = *ipnet
-	return nil
-}
 
 // RunParams encapsulates the runtime parameters for this test.
 type RunParams struct {
@@ -71,8 +42,8 @@ type RunParams struct {
 	// the "data" network interface.
 	//
 	// This will be 127.1.0.0/16 when using the local exec runner.
-	TestSubnet    *IPNet    `json:"network,omitempty"`
-	TestStartTime time.Time `json:"start_time,omitempty"`
+	TestSubnet    *ptypes.IPNet `json:"network,omitempty"`
+	TestStartTime time.Time     `json:"start_time,omitempty"`
 }
 
 // ParseRunParams parses a list of environment variables into a RunParams.
@@ -285,12 +256,12 @@ func toBool(s string) bool {
 }
 
 // toNet might parse any input, so it is possible to get an error and nil return value
-func toNet(s string) *IPNet {
+func toNet(s string) *ptypes.IPNet {
 	_, ipnet, err := net.ParseCIDR(s)
 	if err != nil {
 		return nil
 	}
-	return &IPNet{IPNet: *ipnet}
+	return &ptypes.IPNet{IPNet: *ipnet}
 }
 
 // Try to parse the time.

--- a/runtime/test_utils.go
+++ b/runtime/test_utils.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/testground/sdk-go/ptypes"
 )
 
 // RandomTestRunEnv generates a random RunEnv for testing purposes.
@@ -29,7 +31,7 @@ func RandomTestRunEnv(t *testing.T) (re *RunEnv, cleanup func()) {
 		TestSidecar:            false,
 		TestCase:               fmt.Sprintf("testcase-%d", rand.Uint32()),
 		TestRun:                fmt.Sprintf("testrun-%d", rand.Uint32()),
-		TestSubnet:             &IPNet{IPNet: *subnet},
+		TestSubnet:             &ptypes.IPNet{IPNet: *subnet},
 		TestInstanceCount:      int(1 + (rand.Uint32() % 999)),
 		TestInstanceRole:       "",
 		TestInstanceParams:     make(map[string]string),


### PR DESCRIPTION
Unfortunately, `sdk-go` is the source of truth for Testground on some types. Right now I'm just changing the names in the JSON encoding so when we type them in `sdk-js`, we don't end up with a weird mix of capitalized and uncapitalized things. However, it is my opinion that we should move this types to the main repo!

It is a breaking change because both Testground and this need to be updated in order to work.