### PR TITLE
add support for capturing profiles.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/influxdata/influxdb1-client v0.0.0-20200515024757-02f0bf5dbca3
 	github.com/prometheus/client_golang v1.7.1
+	github.com/raulk/clock v1.1.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/raulk/clock v1.1.0 h1:dpb29+UKMbLqiU/jqIJptgLR1nn23HLgMY0sTCDza5Y=
+github.com/raulk/clock v1.1.0/go.mod h1:3MpVxdZ/ODBQDxbN+kzshf5OSZwPjtMDx6BBXBmOeY0=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/run/invoker.go
+++ b/run/invoker.go
@@ -1,15 +1,21 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"path/filepath"
 	"runtime/debug"
+	"runtime/pprof"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/testground/sdk-go"
@@ -140,6 +146,12 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 		}
 	}()
 
+	closeProfiles, err := captureProfiles(runenv)
+	if err != nil {
+		runenv.SLogger().Warnw("some or all profile captures failed to initialize", "error", err)
+	}
+	defer closeProfiles()
+
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)
@@ -172,6 +184,85 @@ func invoke(runenv *runtime.RunEnv, fn interface{}) {
 		runenv.RecordCrash(p.DebugStacktrace)
 		panic(p.RecoverObj)
 	}
+}
+
+type ProfilesCloseFn = func() error
+
+func captureProfiles(runenv *runtime.RunEnv) (ProfilesCloseFn, error) {
+	outDir := runenv.TestOutputsPath
+
+	var (
+		merr        *multierror.Error
+		wg          sync.WaitGroup
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+
+	ret := func() error {
+		// stop the CPU profile.
+		pprof.StopCPUProfile()
+		// cancel all other profiles, and wait until they have yielded.
+		cancel()
+		wg.Wait()
+		return nil
+	}
+
+	for kind, value := range runenv.TestCaptureProfiles {
+		switch kind {
+		case "cpu":
+			path := filepath.Join(outDir, "cpu.prof")
+			f, err := os.Create(path)
+			if err != nil {
+				err = fmt.Errorf("failed to create CPU profile output file: %w", err)
+				merr = multierror.Append(merr, err)
+				continue
+			}
+			if err = pprof.StartCPUProfile(f); err != nil {
+				err = fmt.Errorf("failed to start capturing CPU profile: %w", err)
+				merr = multierror.Append(merr, err)
+				continue
+			}
+
+		default:
+			prof := pprof.Lookup(kind)
+			if prof == nil {
+				merr = multierror.Append(merr, fmt.Errorf("profile of kind %s not recognized; skipped", kind))
+				continue
+			}
+			freq, err := time.ParseDuration(value)
+			if err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("unparseable duration for profile of kind %s: %s", kind, value))
+				continue
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				ticker := time.NewTicker(freq)
+				for i := 0; ; i++ {
+					select {
+					case <-ticker.C:
+						path := filepath.Join(outDir, fmt.Sprintf("%s.%d.prof", kind, i))
+						f, err := os.Create(path)
+						if err != nil {
+							runenv.SLogger().Warnw("failed to create output file for profile", "kind", kind, "path", path, "error", err)
+							continue
+						}
+						if err = prof.WriteTo(f, 0); err != nil {
+							runenv.SLogger().Warnw("failed to write profile", "kind", kind, "path", path, "error", err)
+							continue
+						}
+						_ = f.Close()
+					case <-ctx.Done():
+						// exiting
+					}
+				}
+			}()
+
+		}
+	}
+
+	return ret, merr.ErrorOrNil()
 }
 
 func maybeSetupHTTPListener(runenv *runtime.RunEnv) {

--- a/run/invoker.go
+++ b/run/invoker.go
@@ -213,6 +213,8 @@ func captureProfiles(runenv *runtime.RunEnv) (ProfilesCloseFn, error) {
 	for kind, value := range runenv.TestCaptureProfiles {
 		switch kind {
 		case "cpu":
+			runenv.SLogger().Infof("writing cpu profile")
+
 			path := filepath.Join(outDir, "cpu.prof")
 			f, err := os.Create(path)
 			if err != nil {
@@ -247,6 +249,8 @@ func captureProfiles(runenv *runtime.RunEnv) (ProfilesCloseFn, error) {
 				merr = multierror.Append(merr, fmt.Errorf("unparseable duration for profile of kind %s: %s", kind, value))
 				continue
 			}
+
+			runenv.SLogger().Infof("writing %s profile every %s", kind, freq)
 
 			kind := kind
 			wg.Add(1)

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -16,4 +16,5 @@ const (
 	EnvTestStartTime          = "TEST_START_TIME"
 	EnvTestSubnet             = "TEST_SUBNET"
 	EnvTestTag                = "TEST_TAG"
+	EnvTestCaptureProfiles    = "TEST_CAPTURE_PROFILES"
 )

--- a/runtime/runparams.go
+++ b/runtime/runparams.go
@@ -44,6 +44,15 @@ type RunParams struct {
 	// This will be 127.1.0.0/16 when using the local exec runner.
 	TestSubnet    *ptypes.IPNet `json:"network,omitempty"`
 	TestStartTime time.Time     `json:"start_time,omitempty"`
+
+	// TestCaptureProfiles lists the profile types to capture. These are
+	// SDK-dependent. The Go SDK supports these profiles:
+	//
+	// * cpu => value ignored; CPU profile spans the entire life of the test.
+	// * any supported profile type https://golang.org/pkg/runtime/pprof/#Profile =>
+	//   value is a string representation of time.Duration, referring to
+	//   the frequency at which profiles will be captured.
+	TestCaptureProfiles map[string]string `json:"capture_profiles,omitempty"`
 }
 
 // ParseRunParams parses a list of environment variables into a RunParams.
@@ -69,6 +78,7 @@ func ParseRunParams(env []string) (*RunParams, error) {
 		TestStartTime:          toTime(EnvTestStartTime),
 		TestSubnet:             toNet(m[EnvTestSubnet]),
 		TestTag:                m[EnvTestTag],
+		TestCaptureProfiles:    unpackParams(m[EnvTestCaptureProfiles]),
 	}, nil
 }
 
@@ -97,6 +107,7 @@ func (rp *RunParams) ToEnvVars() map[string]string {
 		EnvTestStartTime:          rp.TestStartTime.Format(time.RFC3339),
 		EnvTestSubnet:             rp.TestSubnet.String(),
 		EnvTestTag:                rp.TestTag,
+		EnvTestCaptureProfiles:    packParams(rp.TestCaptureProfiles),
 	}
 
 	return out

--- a/runtime/runparams.go
+++ b/runtime/runparams.go
@@ -84,6 +84,9 @@ func ParseRunParams(env []string) (*RunParams, error) {
 
 func (rp *RunParams) ToEnvVars() map[string]string {
 	packParams := func(in map[string]string) string {
+		if in == nil {
+			return ""
+		}
 		arr := make([]string, 0, len(in))
 		for k, v := range in {
 			arr = append(arr, k+"="+v)


### PR DESCRIPTION
This PR adds support for capturing profiles during the lifetime of a test. It introduces:

* A new `TEST_CAPTURE_PROFILES` env variable that lists [profiles types](https://golang.org/pkg/runtime/pprof/#Profile) to capture, and frequencies of capture for each.
* The corresponding `RunParams` field.
* The logic to start profile capture at the beginning of the test instance, and to wind it down cleanly at the end of the test.

TODO:

- [x] PR for `testground/testground`: https://github.com/testground/testground/pull/1209
- [x] Unit tests.