### PR TITLE
fix: fail when message cannot be unmarshalled

### DIFF
--- a/sync/client_consumer.go
+++ b/sync/client_consumer.go
@@ -167,8 +167,7 @@ RegenerateConnection:
 				payload := msg.Values[RedisPayloadKey]
 				val, err := sub.topic.decodePayload(payload)
 				if err != nil {
-					sc.log.Debugw("XREAD response: failed to decode message", "key", xr.Stream, "error", err, "id", msg.ID)
-					continue
+					sc.log.Fatalw("XREAD response: failed to decode message", "key", xr.Stream, "error", err, "id", msg.ID)
 				}
 
 				sc.log.Debugw("dispatching message to subscriber", "key", xr.Stream, "id", msg.ID)


### PR DESCRIPTION
Fixes https://github.com/testground/testground/issues/1226. As OP said:

> It's better to fail the whole test immediately if the payload can not be decoded, so developers won't repetitively fall into the trap.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>