### PR TITLE
Revert "feat: emit periodic goroutine dumps"

### DIFF
--- a/runtime/env.go
+++ b/runtime/env.go
@@ -18,5 +18,4 @@ const (
 	EnvTestTag                = "TEST_TAG"
 	EnvTestCaptureProfiles    = "TEST_CAPTURE_PROFILES"
 	EnvTestTempPath           = "TEST_TEMP_PATH"
-	EnvTestEmitDumps          = "TEST_EMIT_DUMPS"
 )

--- a/runtime/runenv.go
+++ b/runtime/runenv.go
@@ -2,10 +2,7 @@ package runtime
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path/filepath"
-	"runtime/pprof"
 	gosync "sync"
 	"time"
 
@@ -41,7 +38,6 @@ type RunEnv struct {
 	wg        gosync.WaitGroup
 	closeCh   chan struct{}
 	assetsErr error
-	dumpsErr  error
 
 	unstructured struct {
 		files []*os.File
@@ -71,11 +67,6 @@ func NewRunEnv(params RunParams) *RunEnv {
 
 	re.wg.Add(1)
 	go re.manageAssets()
-
-	if re.TestEmitDumps > 0 {
-		re.wg.Add(1)
-		go re.emitDumps()
-	}
 
 	re.metrics = newMetrics(re)
 
@@ -130,38 +121,6 @@ func (re *RunEnv) manageAssets() {
 	}
 }
 
-func (re *RunEnv) emitDumps() {
-	defer re.wg.Done()
-	interval := time.Second * time.Duration(re.TestEmitDumps)
-
-	var err *multierror.Error
-	defer func() { re.dumpsErr = err.ErrorOrNil() }()
-
-	filename := filepath.Join(re.TestOutputsPath, "goroutines.prof")
-
-	w, e := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	if e != nil {
-		err = multierror.Append(err, e)
-		return
-	}
-	defer w.Close()
-
-	for {
-		select {
-		case <-time.After(interval):
-			timestamp := time.Now().UTC().Format(time.RFC3339)
-
-			_, e := fmt.Fprintln(w, timestamp)
-			err = multierror.Append(err, e)
-
-			e = pprof.Lookup("goroutine").WriteTo(w, 1)
-			err = multierror.Append(err, e)
-		case <-re.closeCh:
-			return
-		}
-	}
-}
-
 func (re *RunEnv) Close() error {
 	var err *multierror.Error
 
@@ -171,7 +130,7 @@ func (re *RunEnv) Close() error {
 	// This close stops monitoring the wapi errors channel, and closes assets.
 	close(re.closeCh)
 	re.wg.Wait()
-	err = multierror.Append(err, re.assetsErr, re.dumpsErr)
+	err = multierror.Append(err, re.assetsErr)
 
 	if l := re.logger; l != nil {
 		_ = l.Sync()

--- a/runtime/runparams.go
+++ b/runtime/runparams.go
@@ -54,10 +54,6 @@ type RunParams struct {
 	//   value is a string representation of time.Duration, referring to
 	//   the frequency at which profiles will be captured.
 	TestCaptureProfiles map[string]string `json:"capture_profiles,omitempty"`
-
-	// Periodically emit goroutine dumps.
-	// When TestEmitDumps > 0, Testground emits every TestEmitDumps seconds a pprof goroutines report - the stack traces of all current goroutines.
-	TestEmitDumps int `json:"emit_dumps,omitempty"`
 }
 
 // ParseRunParams parses a list of environment variables into a RunParams.
@@ -85,7 +81,6 @@ func ParseRunParams(env []string) (*RunParams, error) {
 		TestSubnet:             toNet(m[EnvTestSubnet]),
 		TestTag:                m[EnvTestTag],
 		TestCaptureProfiles:    unpackParams(m[EnvTestCaptureProfiles]),
-		TestEmitDumps:          toInt(m[EnvTestEmitDumps]),
 	}, nil
 }
 
@@ -119,7 +114,6 @@ func (rp *RunParams) ToEnvVars() map[string]string {
 		EnvTestSubnet:             rp.TestSubnet.String(),
 		EnvTestTag:                rp.TestTag,
 		EnvTestCaptureProfiles:    packParams(rp.TestCaptureProfiles),
-		EnvTestEmitDumps:          strconv.Itoa(rp.TestEmitDumps),
 	}
 
 	return out


### PR DESCRIPTION
Reverts testground/sdk-go#41.

The feature is already covered by https://github.com/testground/sdk-go/pull/38 and https://github.com/testground/testground/pull/1209 by using the "goroutines" profile.