### PR TITLE
Fix race condition causing panic

### DIFF
--- a/sync/client_conn.go
+++ b/sync/client_conn.go
@@ -35,13 +35,13 @@ func (c *DefaultClient) responsesWorker() {
 		var ch chan *sync.Response
 		c.handlersMu.Lock()
 		ch = c.handlers[res.ID]
-		c.handlersMu.Unlock()
-
 		if ch == nil {
 			c.log.Warnf("no handler available for response: %s", res.ID)
 		} else {
 			ch <- res
 		}
+		c.handlersMu.Unlock()
+
 	}
 
 	c.wg.Done()


### PR DESCRIPTION
I am getting the following panic using testground:

```
Jan  6 06:53:27.928793	INFO	0.6887s      ERROR << requestors[000] (cbbb4e) >> panic: send on closed channel
Jan  6 06:53:27.928936	INFO	0.6889s      ERROR << requestors[000] (cbbb4e) >> 
Jan  6 06:53:27.930237	INFO	0.6902s      ERROR << requestors[000] (cbbb4e) >> goroutine 90 [running]:
Jan  6 06:53:27.930321	INFO	0.6903s      ERROR << requestors[000] (cbbb4e) >> github.com/testground/sdk-go/sync.(*DefaultClient).responsesWorker(0x40003b2230)
Jan  6 06:53:27.930361	INFO	0.6904s      ERROR << requestors[000] (cbbb4e) >> 	/go/pkg/mod/github.com/testground/sdk-go@v0.3.1-0.20211012114808-49c90fa75405/sync/client_conn.go:43 +0x104
Jan  6 06:53:27.930398	INFO	0.6904s      ERROR << requestors[000] (cbbb4e) >> created by github.com/testground/sdk-go/sync.newClient
Jan  6 06:53:27.930432	INFO	0.6904s      ERROR << requestors[000] (cbbb4e) >> 	/go/pkg/mod/github.com/testground/sdk-go@v0.3.1-0.20211012114808-49c90fa75405/sync/client.go:118 +0x1ac
```

Looking at the code, what I assume is happening is between the time the channel is accessed from within the mutex lock in responseWorker and the time the response is sent to the channel, it's being closed, most likely here:
https://github.com/testground/sdk-go/blob/master/sync/client_conn.go#L80

My solution is just to move the unlock a few lines down to after the send.

