### PR TITLE
Support running tests on arm processors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/testground/sync-service v0.1.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	nhooyr.io/websocket v1.8.6
 )

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,9 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
Builds are failing on Mac with arm processors with the following errors:
```
testground run single --plan example --testcase output  --builder exec:go --runner local:exec  --instances 3 --wait
Sep  7 20:35:26.172736  ERROR   go build failed: # golang.org/x/sys/unix
/Users/walid/.go/pkg/mod/golang.org/x/sys@v0.0.0-20200625212154-ddb9806d33ae/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
/Users/walid/.go/pkg/mod/golang.org/x/sys@v0.0.0-20200625212154-ddb9806d33ae/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
```

Running the same example test passes by overriding sdk-go dependency to use the version in this PR
```
vi testground/plans/example/go.mod
replace github.com/testground/sdk-go => /Users/walid/ProtocolLabs/workspace/testground-sdk-go

> testground run single --plan example --testcase output  --builder exec:go --runner local:exec  --instances 3 --wait
// passes
```
