### PR TITLE
sync: fix "send on closed channel" panic in responsesWorker at teardown

### DIFF
--- a/sync/client.go
+++ b/sync/client.go
@@ -33,8 +33,17 @@ type DefaultClient struct {
 	nextMu     sync.Mutex
 	next       int
 	handlersMu sync.Mutex
-	handlers   map[string]chan *tgsync.Response
+	handlers   map[string]*pendingRequest
 	socket     *websocket.Conn
+}
+
+// pendingRequest is the per-request response handler. done is closed by the
+// request's cancellation goroutine to tell responsesWorker to stop delivering;
+// the channel ch is NEVER closed (responsesWorker is its only sender), so a
+// late response can never panic on send-to-closed.
+type pendingRequest struct {
+	ch   chan *tgsync.Response
+	done chan struct{}
 }
 
 // NewBoundClient returns a new sync DefaultClient that is bound to the provided
@@ -99,7 +108,7 @@ func newClient(ctx context.Context, log *zap.SugaredLogger, extractor func(ctx c
 		cancel:    cancel,
 		log:       log,
 		extractor: extractor,
-		handlers:  map[string]chan *tgsync.Response{},
+		handlers:  map[string]*pendingRequest{},
 	}
 
 	c.sugarOperations = &sugarOperations{c}

--- a/sync/client_conn.go
+++ b/sync/client_conn.go
@@ -32,15 +32,21 @@ func (c *DefaultClient) responsesWorker() {
 			c.log.Fatalw("error while reading socket", "error", err)
 		}
 
-		var ch chan *sync.Response
+		var h *pendingRequest
 		c.handlersMu.Lock()
-		ch = c.handlers[res.ID]
+		h = c.handlers[res.ID]
 		c.handlersMu.Unlock()
 
-		if ch == nil {
+		if h == nil {
 			c.log.Warnf("no handler available for response: %s", res.ID)
 		} else {
-			ch <- res
+			// Deliver, or drop if the request was torn down. h.ch is never closed,
+			// so this can never panic on send-to-closed; h.done guarantees we never
+			// block forever on a receiver that has gone away.
+			select {
+			case h.ch <- res:
+			case <-h.done:
+			}
 		}
 	}
 
@@ -57,9 +63,10 @@ func (c *DefaultClient) makeRequest(ctx context.Context, req *sync.Request) (cha
 	}
 
 	ch := make(chan *sync.Response)
+	done := make(chan struct{})
 
 	c.handlersMu.Lock()
-	c.handlers[req.ID] = ch
+	c.handlers[req.ID] = &pendingRequest{ch: ch, done: done}
 	c.handlersMu.Unlock()
 
 	err := c.writeSocket(req)
@@ -77,13 +84,27 @@ func (c *DefaultClient) makeRequest(ctx context.Context, req *sync.Request) (cha
 		}
 
 		c.handlersMu.Lock()
-		close(c.handlers[req.ID])
 		delete(c.handlers, req.ID)
 		c.handlersMu.Unlock()
+		close(done) // tell responsesWorker to stop; ch is intentionally NOT closed
 		c.wg.Done()
 	}()
 
 	return ch, nil
+}
+
+// awaitResponse waits for the single response to a one-shot request, or for the
+// request or client context to be cancelled. The handler channel is never closed,
+// so the context is the only unblock.
+func (c *DefaultClient) awaitResponse(ctx context.Context, ch chan *sync.Response) (*sync.Response, error) {
+	select {
+	case res := <-ch:
+		return res, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.ctx.Done():
+		return nil, errors.New("client closed before getting response")
+	}
 }
 
 func (c *DefaultClient) readSocket() (*sync.Response, error) {

--- a/sync/client_pubsub.go
+++ b/sync/client_pubsub.go
@@ -22,9 +22,9 @@ func (c *DefaultClient) publish(ctx context.Context, topic string, payload inter
 		return -1, err
 	}
 
-	res, ok := <-ch
-	if !ok {
-		return -1, errors.New("channel closed before getting response")
+	res, err := c.awaitResponse(ctx, ch)
+	if err != nil {
+		return -1, err
 	}
 	if res.Error != "" {
 		return -1, errors.New(res.Error)

--- a/sync/client_state.go
+++ b/sync/client_state.go
@@ -59,9 +59,9 @@ func (c *DefaultClient) Barrier(ctx context.Context, state State, target int) (*
 	}
 
 	go func() {
-		res, ok := <-ch
-		if !ok {
-			b.C <- errors.New("channel closed before getting response")
+		res, err := c.awaitResponse(ctx, ch)
+		if err != nil {
+			b.C <- err
 		} else if res.Error == "" {
 			b.C <- nil
 		} else {
@@ -99,9 +99,9 @@ func (c *DefaultClient) SignalEntry(ctx context.Context, state State) (int64, er
 		return -1, err
 	}
 
-	res, ok := <-ch
-	if !ok {
-		return -1, errors.New("channel closed before getting response")
+	res, err := c.awaitResponse(ctx, ch)
+	if err != nil {
+		return -1, err
 	}
 	if res.Error != "" {
 		return -1, errors.New(res.Error)


### PR DESCRIPTION
## Problem

`(*DefaultClient).responsesWorker` panics with `send on closed channel` and crashes the process at teardown:

```
panic: send on closed channel
goroutine N [running]:
github.com/testground/sdk-go/sync.(*DefaultClient).responsesWorker(...)
    .../sync/client_conn.go:43
created by github.com/testground/sdk-go/sync.newClient
    .../sync/client.go:118
```

I hit this reliably while running the **testground daemon** for a multi-instance test: at run teardown (right after `all containers are complete` / `deleting containers`) the daemon's sync client panics, the daemon process dies, and every subsequent `testground run` then fails with `dial tcp [::1]:8042: connect: connection refused` — the run reports `outcome ... canceled`.

## Root cause — a close-vs-send race on the handler channel

In `sync/client_conn.go`:

- `responsesWorker()` looks up the per-request handler channel **under** `handlersMu`, **releases the lock**, then sends `ch <- res` **unlocked**.
- `makeRequest()`'s ctx-cancellation goroutine, on teardown, takes `handlersMu`, then `close(c.handlers[req.ID])`, `delete(...)`, unlocks.

If a response arrives for a request whose handler is closed in the window between `responsesWorker` releasing the lock and performing the send, `responsesWorker` sends on a now-closed channel → panic. It's probabilistic (more in-flight requests / teardown timing → more likely); low-traffic runs often dodge it, busy ones hit it every time.

A third goroutine closing the channel that `responsesWorker` is the sole sender of is the underlying problem — in Go the sender should own the close, and there must be no send after close.

> Note: wrapping the send in a `select { case ch <- res: case <-done: }` does **not** fix this — a send case on a *closed* channel is still "ready" and may be chosen, so it still panics. The send must never see a closed channel.

## Fix — never close the handler channel from the cancel goroutine

Make `responsesWorker` the channel's only writer and never close `ch` from a third goroutine; use a per-request `done` channel for teardown signalling, and unblock one-shot receivers via the context instead of via channel-close.

- Each handler is now a `pendingRequest{ ch, done }`. The cancel goroutine `delete`s the handler and `close(done)` — it **never closes `ch`**.
- `responsesWorker` delivers with `select { case h.ch <- res: case <-h.done: }`: it can never panic on send-to-closed (`ch` is never closed), and never blocks forever (`done` is closed when the request/client context fires — every caller wraps the request in a cancellable context with `defer cancel()`).
- Because `ch` is no longer closed, the one-shot receivers (`publish`, `SignalEntry`, and the `Barrier` goroutine) unblock via context through a small helper:

  ```go
  func (c *DefaultClient) awaitResponse(ctx context.Context, ch chan *sync.Response) (*sync.Response, error) {
      select {
      case res := <-ch:
          return res, nil
      case <-ctx.Done():
          return nil, ctx.Err()
      case <-c.ctx.Done():
          return nil, errors.New("client closed before getting response")
      }
  }
  ```

- `subscribe` already selects on `c.ctx.Done()` / `ctx.Done()` / `resCh`, so it still terminates via its contexts (the `resCh` close branch simply becomes unreachable); streaming delivery still works through the send-vs-`done` select.

## Verification

- `go build ./...` and `go vet ./sync/` pass; `gofmt` clean on all changed files.
- Reviewed for the four failure modes: (1) `grep close(` confirms `ch` is never closed anywhere (only `done`); (2) `done` is always eventually closed for every registered handler, so `responsesWorker` never blocks; (3) every one-shot receiver unblocks on both the request ctx and the client ctx (no hang); (4) `subscribe` still terminates and streams.
- The equivalent minimal fix (a `recover()` around the racy send) was additionally **runtime-confirmed**: with it, a 3-instance multi-impl testground run that previously crashed the daemon at teardown completed cleanly (`outcome = success`) across repeated runs. This PR is the cleaner, structural form of that same fix.

## Alternative

If you'd prefer the minimal change, a one-line `recover()` around the send also stops the crash without the refactor — happy to switch to that if that's more in line with how you'd like to fix it.
